### PR TITLE
chrootcfg: expand chrootcontroller class

### DIFF
--- a/src/modules/chrootcfg/chrootcfg.conf
+++ b/src/modules/chrootcfg/chrootcfg.conf
@@ -1,10 +1,20 @@
 ---
-requirements:
-    - directory: /etc
-    - directory: /var/log
-    - directory: /var/cache/pacman/pkg
-    - directory: /var/lib/pacman
+directories:
+    - name: /etc
+      mode: 755
+    - name: /var/log
+      mode: 755
+    - name: /var/cache/pacman/pkg
+      mode: 755
+    - name: /var/lib/pacman
+      mode: 755
 
-packages:
+requirements:
     - pacman
     - linux44
+
+keyrings:
+    - archlinux
+    - manjaro
+
+branch: stable


### PR DESCRIPTION
- expand ChrootController class
- add PacmanController class

possible ToDo:
- properly set dir mode(unused, defaults 0o755 oct)
- send progress update to UI

The PR goes together with this https://github.com/manjaro/manjaro-tools/commit/309bce9d06ebb719b6b54b34fda3d7fbf4c1339e

Should be 0.13.1 release after PR merge.

![cal-net](https://s32.postimg.org/phq7kkymr/cal_net3.png)

install.log from vbox:

```
01:43:44 [1]: Calamares version: 2.3.91.r2382.c197985
01:43:44 [1]: Default font =====
Pixel size:    -1
Point size:    9
Point sizeF:   9
Font family:   "Sans Serif"
Metric height: 14
01:43:44 [1]: Font height: 14
01:43:44 [1]: Available languages: ("ar", "ast", "bg", "ca", "cs_CZ", "da", "de", "el", "en", "en_GB", "es_MX", "es", "eu", "fr", "hr", "hu", "id", "is", "it_IT", "ja", "lt", "nl", "pl", "pt_BR", "pt_PT", "ro", "ru", "sk", "sv", "th", "tr_TR", "zh_CN", "zh_TW")
m_crashReporterWChar: /usr/bin/../libexec/calamares_crash_reporter01:43:44 [1]: CalamaresApplication thread: 0xf771b0
01:43:44 [1]: Using log file: "/root/.cache/Calamares/Calamares/Calamares.log"
01:43:44 [1]: Using Calamares settings file at "/etc/calamares/settings.conf"
01:43:44 [1]: Using Calamares branding file at "/usr/share/calamares/branding/manjaro/branding.desc"
01:43:44 [1]: WARNING: the selected branding component does not ship translations.
01:43:44 [1]: Loaded branding component "manjaro"
01:43:44 [1]: STARTUP: initQmlPath, initSettings, initBranding done
01:43:44 [1]: STARTUP: initModuleManager: module init started
01:43:44 [1]: STARTUP: initModuleManager: all modules init done
01:43:44 [1]: STARTUP: initJobQueue done
01:43:44 [1]: Proposed window size: 1010 520
01:43:44 [1]: STARTUP: CalamaresWindow created; loadModules started
01:43:44 [1]: Initial locale  "de_DE"
01:43:44 [8]: Translation: Calamares: Using system locale: "de_DE"
01:43:44 [8]: Translation: Qt: Using default locale, system locale one not found: "de_DE"
01:43:44 [1]: ViewModule loading self for instance "welcome@welcome"
ViewModule at address 0x1149b50
Calamares::PluginFactory at address WelcomeViewStepFactory(0x101e870)
ViewStep at address WelcomeViewStep(0x1149a40)
01:43:44 [1]: ViewModule loading self for instance "netinstall@netinstall"
ViewModule at address 0xfdc190
Calamares::PluginFactory at address NetInstallViewStepFactory(0xfd6440)
ViewStep at address NetInstallViewStep(0x117b270)
01:43:44 [1]: ViewModule loading self for instance "locale@locale"
ViewModule at address 0x119c2f0
Calamares::PluginFactory at address LocaleViewStepFactory(0x11c8a40)
ViewStep at address LocaleViewStep(0x11cf2a0)
01:43:45 [1]: ViewModule loading self for instance "keyboard@keyboard"
ViewModule at address 0x11d1670
Calamares::PluginFactory at address KeyboardViewStepFactory(0x11cac40)
ViewStep at address KeyboardViewStep(0x11d19f0)
01:43:45 [8]: Loaded backend plugin:  "pmlibpartedbackendplugin"
01:43:45 [1]: ViewModule loading self for instance "partition@partition"
ViewModule at address 0x100ab10
Calamares::PluginFactory at address PartitionViewStepFactory(0x3507810)
ViewStep at address PartitionViewStep(0x34ff380)
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [1]: ViewModule loading self for instance "users@users"
ViewModule at address 0x351af00
Calamares::PluginFactory at address UsersViewStepFactory(0x351d140)
ViewStep at address UsersViewStep(0x351b050)
01:43:45 [1]: ViewModule loading self for instance "summary@summary"
ViewModule at address 0x3542880
Calamares::PluginFactory at address SummaryViewStepFactory(0x35427d0)
ViewStep at address SummaryViewStep(0x3543060)
01:43:45 [1]: Module "partition@partition" already loaded.
01:43:45 [1]: QML import paths: ("/usr/share/calamares/qml", "/usr/bin", "qrc:/qt-project.org/imports", "/usr/lib/qt/qml")
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: Module "locale@locale" already loaded.
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: Module "keyboard@keyboard" already loaded.
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: Module "users@users" already loaded.
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [0]: void Calamares::Module::loadConfigurationFile(const QString&) bad module configuration format "/usr/share/calamares/modules/umount.conf"
01:43:45 [1]: LAST VS IS EVS!
01:43:45 [1]: ViewModule loading self for instance "finished@finished"
ViewModule at address 0x358f030
Calamares::PluginFactory at address FinishedViewStepFactory(0x358ba70)
ViewStep at address FinishedViewStep(0x358bbc0)
01:43:45 [1]: STARTUP: loadModules for all modules done
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [1]: STARTUP: Window now visible and ProgressTreeView populated
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [8]: Unknown property Schriftstil
01:43:45 [1]: Need at least storage bytes: -1073741824
01:43:45 [1]: Need at least ram bytes: 0
01:43:45 [1]: enoughStorage, enoughRam, hasPower, hasInternet, isRoot:  false false false false false
01:43:45 [1]: xkbmap selection changed to:  "de" - "nodeadkeys"
01:43:46 [8]: getting smart status failed for  "/dev/sda" :  Die Operation wird nicht unterstützt
01:43:46 [0]: QFileInfo::absolutePath: Constructed with empty filename
01:43:46 [8]: getting smart status failed for  "/dev/sdb" :  Die Operation wird nicht unterstützt
01:43:46 [0]: QFileInfo::absolutePath: Constructed with empty filename
01:43:46 [0]: QFileInfo::absolutePath: Constructed with empty filename
01:43:46 [1]: LIST OF DETECTED DEVICES:
node    capacity    name    prettyName
01:43:46 [1]: "/dev/sda" 17174384640 "ATA VBOX HARDDISK" "ATA VBOX HARDDISK – 15,99 GiB (/dev/sda)"
01:43:46 [1]: "/dev/sdb" 17174384640 "ATA VBOX HARDDISK" "ATA VBOX HARDDISK – 15,99 GiB (/dev/sdb)"
01:43:49 [1]: Leaving netinstall, adding packages to be installed to global storage
01:44:17 [1]: checking if "/dev/sdb1" can be resized.
01:44:17 [1]: "/dev/sdb1" seems like a good path
01:44:17 [1]: found Partition* for "/dev/sdb1"
01:44:17 [1]: "Osprober lines, clean:\n/dev/sdb1:unknown Linux distribution:Linux:linux"
01:44:17 [1]: Updating partitioning state widgets.
01:44:17 [0]: QCoreApplication::postEvent: Unexpected null receiver
01:44:17 [1]: Creating immutable copy for node: "/dev/sda"
01:44:17 [8]: getting smart status failed for  "/dev/sda" :  Die Operation wird nicht unterstützt
01:44:17 [0]: QFileInfo::absolutePath: Constructed with empty filename
01:44:17 [1]: Required  storage B: 2684354560 "(2GB)"
01:44:17 [1]: Available storage B: 7590929408 "(7GB)"
01:44:17 [1]: Required  storage B: 2684354560 "(2GB)"
01:44:17 [1]: Available storage B: -1 "(0GB)"
01:44:17 [1]: Required  storage B: 536870912 "(0GB)"
01:44:17 [1]: Available storage B: 8045368320 "(7GB)"
01:44:17 [1]: Required  storage B: 536870912 "(0GB)"
01:44:17 [1]: Available storage B: 9127967232 "(8GB)"
01:44:17 [1]: Updating partitioning preview widgets.
01:44:17 [0]: QCoreApplication::postEvent: Unexpected null receiver
01:44:28 [1]: CreatePartitionTableJob::createTable trying to make table for device "/dev/sda"
01:44:28 [1]: Suggested swap size: 8.50108 GiB
01:44:28 [1]: # Queue:
01:44:28 [1]: ## Device: "ATA VBOX HARDDISK"
01:44:28 [1]: - "Erstelle eine neue msdos Partitionstabelle auf /dev/sda."
01:44:28 [1]: - "Erstelle eine neue Partition mit einer Größe von 7672MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem ext4."
01:44:28 [1]: - "Erstelle eine neue Partition mit einer Größe von 8705MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem Linux-Swap."
01:44:28 [1]: ## Device: "ATA VBOX HARDDISK"
01:44:28 [1]: Updating partitioning preview widgets.
01:44:28 [0]: QCoreApplication::postEvent: Unexpected null receiver
01:44:43 [0]: QLayout: Attempting to add QLayout "" to QWidget "", which already has a layout
01:44:43 [8]: getting smart status failed for  "/dev/sda" :  Die Operation wird nicht unterstützt
01:44:43 [0]: QFileInfo::absolutePath: Constructed with empty filename
01:44:43 [1]: PartitionCodeModule has been asked for jobs. About to return: "Alle temporären Mount-Points leeren.\nLeere Mount-Points für Partitioning-Operation auf /dev/sda\nErstelle eine neue msdos Partitionstabelle auf /dev/sda.\nErstelle eine neue Partition mit einer Größe von 7672MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem ext4.\nErstelle eine neue Partition mit einer Größe von 8705MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem Linux-Swap.\nSetze Partitionsinformationen"
01:44:43 [1]: Gathering UUIDs for partitions that exist now.
01:44:43 [1]: QHash(("", "")("/dev/sdb2", "fcbb0f00-24ba-4241-ac56-986c46bf2810")("/dev/sdb1", "f7c54069-f3d5-4543-97b0-c8fc6e808320"))
01:44:43 [1]: Writing to GlobalStorage["partitions"]
01:44:43 [1]: "" mtpoint: "/" fs: "ext4" ""
01:44:43 [1]: "" mtpoint: "" fs: "Linux-Swap" ""
01:44:43 [1]: "/dev/sdb1" mtpoint: "" fs: "unbekannt" "f7c54069-f3d5-4543-97b0-c8fc6e808320"
01:44:43 [1]: "/dev/sdb2" mtpoint: "" fs: "unbekannt" "fcbb0f00-24ba-4241-ac56-986c46bf2810"
01:44:43 [8]: QVariant(QString, "") "" "/" "ext4"
01:44:43 [8]: QVariant(QString, "") "" "" "Linux-Swap"
01:44:43 [8]: QVariant(QString, "f7c54069-f3d5-4543-97b0-c8fc6e808320") "/dev/sdb1" "" "unbekannt"
01:44:43 [8]: QVariant(QString, "fcbb0f00-24ba-4241-ac56-986c46bf2810") "/dev/sdb2" "" "unbekannt"
01:44:43 [1]: Gathering UUIDs for partitions that exist now.
01:44:43 [1]: QHash(("", "")("/dev/sdb2", "fcbb0f00-24ba-4241-ac56-986c46bf2810")("/dev/sdb1", "f7c54069-f3d5-4543-97b0-c8fc6e808320"))
01:44:43 [1]: Writing to GlobalStorage["partitions"]
01:44:43 [1]: "" mtpoint: "/" fs: "ext4" ""
01:44:43 [1]: "" mtpoint: "" fs: "Linux-Swap" ""
01:44:43 [1]: "/dev/sdb1" mtpoint: "" fs: "unbekannt" "f7c54069-f3d5-4543-97b0-c8fc6e808320"
01:44:43 [1]: "/dev/sdb2" mtpoint: "" fs: "unbekannt" "fcbb0f00-24ba-4241-ac56-986c46bf2810"
01:44:43 [8]: QVariant(QString, "") "" "/" "ext4"
01:44:43 [8]: QVariant(QString, "") "" "" "Linux-Swap"
01:44:43 [8]: QVariant(QString, "f7c54069-f3d5-4543-97b0-c8fc6e808320") "/dev/sdb1" "" "unbekannt"
01:44:43 [8]: QVariant(QString, "fcbb0f00-24ba-4241-ac56-986c46bf2810") "/dev/sdb2" "" "unbekannt"
01:44:44 [1]: PartitionCodeModule has been asked for jobs. About to return: "Alle temporären Mount-Points leeren.\nLeere Mount-Points für Partitioning-Operation auf /dev/sda\nErstelle eine neue msdos Partitionstabelle auf /dev/sda.\nErstelle eine neue Partition mit einer Größe von 7672MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem ext4.\nErstelle eine neue Partition mit einer Größe von 8705MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem Linux-Swap.\nSetze Partitionsinformationen"
01:44:44 [0]: Starting job "Alle temporären Mount-Points leeren."
01:44:44 [1]: Opened mtab. Lines:
01:44:44 [1]: "overlay / overlay rw,relatime,lowerdir=/ro_branch/live-image:/ro_branch/mhwd-image:/ro_branch/lxqt-minimal-image:/ro_branch/root-image,upperdir=/rw_branch/upper,workdir=/rw_branch/work 0 0"
01:44:44 [1]: "/dev/sr0 /bootmnt iso9660 ro,noatime 0 0"
01:44:44 [1]: "dev /dev devtmpfs rw,nosuid,relatime,size=2016628k,nr_inodes=504157,mode=755 0 0"
01:44:44 [1]: "tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0"
01:44:44 [1]: "devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0"
01:44:44 [1]: "mqueue /dev/mqueue mqueue rw,relatime 0 0"
01:44:44 [1]: "hugetlbfs /dev/hugepages hugetlbfs rw,relatime 0 0"
01:44:44 [1]: "proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0"
01:44:44 [1]: "systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=24,pgrp=1,timeout=0,minproto=5,maxproto=5,direct 0 0"
01:44:44 [1]: "sys /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0"
01:44:44 [1]: "securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0"
01:44:44 [1]: "tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/systemd cgroup rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/freezer cgroup rw,nosuid,nodev,noexec,relatime,freezer 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/net_cls cgroup rw,nosuid,nodev,noexec,relatime,net_cls 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/devices cgroup rw,nosuid,nodev,noexec,relatime,devices 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/cpuset cgroup rw,nosuid,nodev,noexec,relatime,cpuset 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/blkio cgroup rw,nosuid,nodev,noexec,relatime,blkio 0 0"
01:44:44 [1]: "cgroup /sys/fs/cgroup/pids cgroup rw,nosuid,nodev,noexec,relatime,pids 0 0"
01:44:44 [1]: "pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0"
01:44:44 [1]: "debugfs /sys/kernel/debug debugfs rw,relatime 0 0"
01:44:44 [1]: "configfs /sys/kernel/config configfs rw,relatime 0 0"
01:44:44 [1]: "run /run tmpfs rw,nosuid,nodev,relatime,mode=755 0 0"
01:44:44 [1]: "tmpfs /tmp tmpfs rw,nosuid,nodev 0 0"
01:44:44 [1]: "tmpfs /etc/pacman.d/gnupg tmpfs rw,relatime,mode=755 0 0"
01:44:44 [1]: "tmpfs /tmp tmpfs rw,nosuid,nodev 0 0"
01:44:44 [1]: "overlay /var/tmp overlay rw,relatime,lowerdir=/ro_branch/live-image:/ro_branch/mhwd-image:/ro_branch/lxqt-minimal-image:/ro_branch/root-image,upperdir=/rw_branch/upper,workdir=/rw_branch/work 0 0"
01:44:44 [1]: "tmpfs /run/user/1000 tmpfs rw,nosuid,nodev,relatime,size=405180k,mode=700,uid=1000,gid=1000 0 0"
01:44:44 [1]: "fusectl /sys/fs/fuse/connections fusectl rw,relatime 0 0"
01:44:44 [1]: "gvfsd-fuse /run/user/1000/gvfs fuse.gvfsd-fuse rw,nosuid,nodev,relatime,user_id=1000,group_id=1000 0 0"
01:44:44 [1]: "/dev/sda1 /tmp/calamares-root-bqp6y5s8 ext4 rw,relatime,data=ordered 0 0"
01:44:44 [1]: INSERTING pair (device, mountPoint) "/dev/sda1" "/tmp/calamares-root-bqp6y5s8"
01:44:44 [1]: "proc /tmp/calamares-root-bqp6y5s8/proc proc rw,relatime 0 0"
01:44:44 [1]: INSERTING pair (device, mountPoint) "proc" "/tmp/calamares-root-bqp6y5s8/proc"
01:44:44 [1]: "sys /tmp/calamares-root-bqp6y5s8/sys sysfs rw,relatime 0 0"
01:44:44 [1]: INSERTING pair (device, mountPoint) "sys" "/tmp/calamares-root-bqp6y5s8/sys"
01:44:44 [1]: "dev /tmp/calamares-root-bqp6y5s8/dev devtmpfs rw,nosuid,relatime,size=2016628k,nr_inodes=504157,mode=755 0 0"
01:44:44 [1]: INSERTING pair (device, mountPoint) "dev" "/tmp/calamares-root-bqp6y5s8/dev"
01:44:44 [1]: "tmpfs /tmp/calamares-root-bqp6y5s8/run tmpfs rw,relatime 0 0"
01:44:44 [1]: INSERTING pair (device, mountPoint) "tmpfs" "/tmp/calamares-root-bqp6y5s8/run"
01:44:44 [1]: Will try to umount path "/tmp/calamares-root-bqp6y5s8/run"
01:44:44 [1]: Will try to umount path "/tmp/calamares-root-bqp6y5s8/sys"
01:44:44 [1]: Will try to umount path "/tmp/calamares-root-bqp6y5s8/proc"
01:44:44 [1]: Will try to umount path "/tmp/calamares-root-bqp6y5s8/dev"
01:44:45 [1]: Will try to umount path "/tmp/calamares-root-bqp6y5s8"
01:44:45 [1]: ClearTempMountsJob finished. Here's what was done:
 "Successfully unmounted /tmp/calamares-root-bqp6y5s8/run.\nSuccessfully unmounted /tmp/calamares-root-bqp6y5s8/sys.\nSuccessfully unmounted /tmp/calamares-root-bqp6y5s8/proc.\nSuccessfully unmounted /tmp/calamares-root-bqp6y5s8/dev.\nSuccessfully unmounted /tmp/calamares-root-bqp6y5s8."
01:44:45 [0]: Starting job "Leere Mount-Points für Partitioning-Operation auf /dev/sda"
01:44:45 [1]: ClearMountsJob finished. Here's what was done:
 "Successfully cleared swap /dev/sda2."
01:44:45 [0]: Starting job "Erstelle eine neue msdos Partitionstabelle auf /dev/sda."
01:44:45 [1]: CreatePartitionTableJob::createTable trying to make table for device "/dev/sda"
01:44:45 [1]: Creating new partition table of type "msdos" , uncommitted yet:
 true
01:44:45 [1]: lsblk:
 "NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT\nsda      8:0    0    16G  0 disk \n\xE2\x94\x9C\xE2\x94\x80sda1   8:1    0   7,5G  0 part \n\xE2\x94\x94\xE2\x94\x80sda2   8:2    0   8,5G  0 part \nsdb      8:16   0    16G  0 disk \n\xE2\x94\x9C\xE2\x94\x80sdb1   8:17   0   7,5G  0 part \n\xE2\x94\x94\xE2\x94\x80sdb2   8:18   0   8,5G  0 part \nsr0     11:0    1   700M  0 rom  /bootmnt\nloop0    7:0    0   9,6M  1 loop \nloop1    7:1    0  78,8M  1 loop \nloop2    7:2    0 236,2M  1 loop \nloop3    7:3    0 317,6M  1 loop \n"
01:44:45 [1]: mount:
 "overlay on / type overlay (rw,relatime,lowerdir=/ro_branch/live-image:/ro_branch/mhwd-image:/ro_branch/lxqt-minimal-image:/ro_branch/root-image,upperdir=/rw_branch/upper,workdir=/rw_branch/work)\n/dev/sr0 on /bootmnt type iso9660 (ro,noatime)\ndev on /dev type devtmpfs (rw,nosuid,relatime,size=2016628k,nr_inodes=504157,mode=755)\ntmpfs on /dev/shm type tmpfs (rw,nosuid,nodev)\ndevpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)\nmqueue on /dev/mqueue type mqueue (rw,relatime)\nhugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime)\nproc on /proc type proc (rw,nosuid,nodev,noexec,relatime)\nsystemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=24,pgrp=1,timeout=0,minproto=5,maxproto=5,direct)\nsys on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)\nsecurityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)\ntmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,mode=755)\ncgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd)\ncgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)\ncgroup on /sys/fs/cgroup/net_cls type cgroup (rw,nosuid,nodev,noexec,relatime,net_cls)\ncgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)\ncgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)\ncgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)\ncgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)\ncgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)\ncgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)\npstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)\ndebugfs on /sys/kernel/debug type debugfs (rw,relatime)\nconfigfs on /sys/kernel/config type configfs (rw,relatime)\nrun on /run type tmpfs (rw,nosuid,nodev,relatime,mode=755)\ntmpfs on /tmp type tmpfs (rw,nosuid,nodev)\ntmpfs on /etc/pacman.d/gnupg type tmpfs (rw,relatime,mode=755)\ntmpfs on /tmp type tmpfs (rw,nosuid,nodev)\noverlay on /var/tmp type overlay (rw,relatime,lowerdir=/ro_branch/live-image:/ro_branch/mhwd-image:/ro_branch/lxqt-minimal-image:/ro_branch/root-image,upperdir=/rw_branch/upper,workdir=/rw_branch/work)\ntmpfs on /run/user/1000 type tmpfs (rw,nosuid,nodev,relatime,size=405180k,mode=700,uid=1000,gid=1000)\nfusectl on /sys/fs/fuse/connections type fusectl (rw,relatime)\ngvfsd-fuse on /run/user/1000/gvfs type fuse.gvfsd-fuse (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)\n"
01:44:45 [0]: Starting job "Erstelle eine neue Partition mit einer Größe von 7672MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem ext4."
01:44:48 [0]: Starting job "Erstelle eine neue Partition mit einer Größe von 8705MB auf /dev/sda (ATA VBOX HARDDISK) mit dem Dateisystem Linux-Swap."
01:44:49 [0]: Starting job "Setze Partitionsinformationen"
01:44:49 [1]: Gathering UUIDs for partitions that exist now.
01:44:49 [1]: QHash(("/dev/sda1", "c83308e0-e4c9-4c16-a821-2d318c3fab3d")("/dev/sda2", "1b78ae75-19f3-4167-9357-5b15430f1705")("/dev/sdb2", "fcbb0f00-24ba-4241-ac56-986c46bf2810")("/dev/sdb1", "f7c54069-f3d5-4543-97b0-c8fc6e808320"))
01:44:49 [1]: Writing to GlobalStorage["partitions"]
01:44:49 [1]: "/dev/sda1" mtpoint: "/" fs: "ext4" "c83308e0-e4c9-4c16-a821-2d318c3fab3d"
01:44:49 [1]: "/dev/sda2" mtpoint: "" fs: "Linux-Swap" "1b78ae75-19f3-4167-9357-5b15430f1705"
01:44:49 [1]: "/dev/sdb1" mtpoint: "" fs: "unbekannt" "f7c54069-f3d5-4543-97b0-c8fc6e808320"
01:44:49 [1]: "/dev/sdb2" mtpoint: "" fs: "unbekannt" "fcbb0f00-24ba-4241-ac56-986c46bf2810"
01:44:49 [0]: Starting job "mount"
01:44:49 [0]: Starting job "chrootcfg"
01:44:49 [1]: [PYTHON JOB]:  "Create /etc."
01:44:49 [1]: [PYTHON JOB]:  "Mode 755."
01:44:49 [1]: [PYTHON JOB]:  "Create /var/log."
01:44:49 [1]: [PYTHON JOB]:  "Mode 755."
01:44:49 [1]: [PYTHON JOB]:  "Create /var/cache/pacman/pkg."
01:44:49 [1]: [PYTHON JOB]:  "Mode 755."
01:44:49 [1]: [PYTHON JOB]:  "Create /var/lib/pacman."
01:44:49 [1]: [PYTHON JOB]:  "Mode 755."
:: Synchronisiere Paketdatenbanken...
Lade core.db herunter...
Lade extra.db herunter...
Lade community.db herunter...
Lade multilib.db herunter...
Löse Abhängigkeiten auf...
Suche nach in Konflikt stehenden Paketen...

Pakete (86) acl-2.2.52-2  archlinux-keyring-20160402-1  attr-2.4.47-1  bash-4.3.046-1  bzip2-1.0.6-5  ca-certificates-20160507-1  ca-certificates-cacert-20140824-3  ca-certificates-mozilla-3.25-1  ca-certificates-utils-20160507-1  coreutils-8.25-2  cracklib-2.9.6-1  curl-7.50.0-1  db-5.3.28-3  dbus-1.10.8-1  e2fsprogs-1.43.1-2  expat-2.2.0-1  filesystem-2015.09-1  findutils-4.6.0-1  gawk-4.1.3-1  gcc-libs-6.1.1-3  gdbm-1.12-2  glibc-2.23-5  gmp-6.1.1-1  gnupg-2.1.14-1  gnutls-3.4.14-1  gpgme-1.6.0-2  grep-2.25-2  gzip-1.8-2  hwids-20160421-1  iana-etc-20160513-1  iptables-1.6.0-1  kbd-2.0.3-1  keyutils-1.5.9-1  kmod-23-1  krb5-1.13.4-1  less-481-2  libarchive-3.2.1-2  libassuan-2.4.3-1  libcap-2.25-1  libdbus-1.10.8-1  libelf-0.166-1  libffi-3.2.1-2  libgcrypt-1.7.2-1  libgpg-error-1.24-1  libidn-1.33-1  libksba-1.3.4-1  libldap-2.4.44-2  libmnl-1.0.4-1  libnftnl-1.0.6-1  libsasl-2.1.26-8  libseccomp-2.3.1-1  libssh2-1.7.0-2  libsystemd-231-1  libtasn1-4.9-2  libtirpc-1.0.1-2  libutil-linux-2.28-1  linux-api-headers-4.5.5-1  linux-firmware-20160429.5e6165a-0.1  lz4-131-1  lzo-2.09-1  manjaro-keyring-20160527-1  mkinitcpio-20-1  mkinitcpio-busybox-1.24.2-1  mpfr-3.1.4.p1-1  ncurses-6.0-4  nettle-3.2-2  npth-1.2-1  openssl-1.0.2.h-1  p11-kit-0.23.2-1  pacman-mirrorlist-20160801-1  pam-1.3.0-1  pambase-20130928-1  pcre-8.39-1  perl-5.24.0-1  pinentry-0.9.7-2  python-3.5.2-1  readline-6.3.008-4  shadow-4.2.1-3  sqlite-3.13.0-1  systemd-231-1  tzdata-2016f-1  util-linux-2.28-1  xz-5.2.2-1  zlib-1.2.8-4  linux44-4.4.16-1  pacman-5.0.1-4

Gesamtgröße des Downloads:           184,81 MiB
Gesamtgröße der installierten Pakete:  636,30 MiB

:: Installation fortsetzen? [J/n]
:: Empfange Pakete...
Lade linux-api-headers-4.5.5-1-x86_64.pkg.tar.xz herunter...
Lade tzdata-2016f-1-any.pkg.tar.xz herunter...
Lade iana-etc-20160513-1-any.pkg.tar.xz herunter...
Lade filesystem-2015.09-1-x86_64.pkg.tar.xz herunter...
Lade glibc-2.23-5-x86_64.pkg.tar.xz herunter...
Lade gcc-libs-6.1.1-3-x86_64.pkg.tar.xz herunter...
Lade ncurses-6.0-4-x86_64.pkg.tar.xz herunter...
Lade readline-6.3.008-4-x86_64.pkg.tar.xz herunter...
Lade bash-4.3.046-1-x86_64.pkg.tar.xz herunter...
Lade attr-2.4.47-1-x86_64.pkg.tar.xz herunter...
Lade acl-2.2.52-2-x86_64.pkg.tar.xz herunter...
Lade bzip2-1.0.6-5-x86_64.pkg.tar.xz herunter...
Lade expat-2.2.0-1-x86_64.pkg.tar.xz herunter...
Lade lz4-131-1-x86_64.pkg.tar.xz herunter...
Lade lzo-2.09-1-x86_64.pkg.tar.xz herunter...
Lade gdbm-1.12-2-x86_64.pkg.tar.xz herunter...
Lade db-5.3.28-3-x86_64.pkg.tar.xz herunter...
Lade perl-5.24.0-1-x86_64.pkg.tar.xz herunter...
Lade openssl-1.0.2.h-1-x86_64.pkg.tar.xz herunter...
Lade xz-5.2.2-1-x86_64.pkg.tar.xz herunter...
Lade zlib-1.2.8-4-x86_64.pkg.tar.xz herunter...
Lade libarchive-3.2.1-2-x86_64.pkg.tar.xz herunter...
Lade gmp-6.1.1-1-x86_64.pkg.tar.xz herunter...
Lade libcap-2.25-1-x86_64.pkg.tar.xz herunter...
Lade coreutils-8.25-2-x86_64.pkg.tar.xz herunter...
Lade findutils-4.6.0-1-x86_64.pkg.tar.xz herunter...
Lade libtasn1-4.9-2-x86_64.pkg.tar.xz herunter...
Lade libffi-3.2.1-2-x86_64.pkg.tar.xz herunter...
Lade p11-kit-0.23.2-1-x86_64.pkg.tar.xz herunter...
Lade ca-certificates-utils-20160507-1-any.pkg.tar.xz herunter...
Lade ca-certificates-mozilla-3.25-1-x86_64.pkg.tar.xz herunter...
Lade ca-certificates-cacert-20140824-3-any.pkg.tar.xz herunter...
Lade ca-certificates-20160507-1-any.pkg.tar.xz herunter...
Lade libutil-linux-2.28-1-x86_64.pkg.tar.xz herunter...
Lade e2fsprogs-1.43.1-2-x86_64.pkg.tar.xz herunter...
Lade libsasl-2.1.26-8-x86_64.pkg.tar.xz herunter...
Lade libldap-2.4.44-2-x86_64.pkg.tar.xz herunter...
Lade keyutils-1.5.9-1-x86_64.pkg.tar.xz herunter...
Lade krb5-1.13.4-1-x86_64.pkg.tar.xz herunter...
Lade libidn-1.33-1-x86_64.pkg.tar.xz herunter...
Lade libssh2-1.7.0-2-x86_64.pkg.tar.xz herunter...
Lade curl-7.50.0-1-x86_64.pkg.tar.xz herunter...
Lade libgpg-error-1.24-1-x86_64.pkg.tar.xz herunter...
Lade npth-1.2-1-x86_64.pkg.tar.xz herunter...
Lade libgcrypt-1.7.2-1-x86_64.pkg.tar.xz herunter...
Lade libksba-1.3.4-1-x86_64.pkg.tar.xz herunter...
Lade libassuan-2.4.3-1-x86_64.pkg.tar.xz herunter...
Lade pinentry-0.9.7-2-x86_64.pkg.tar.xz herunter...
Lade nettle-3.2-2-x86_64.pkg.tar.xz herunter...
Lade gnutls-3.4.14-1-x86_64.pkg.tar.xz herunter...
Lade sqlite-3.13.0-1-x86_64.pkg.tar.xz herunter...
Lade gnupg-2.1.14-1-x86_64.pkg.tar.xz herunter...
Lade gpgme-1.6.0-2-x86_64.pkg.tar.xz herunter...
Lade pacman-mirrorlist-20160801-1-any.pkg.tar.xz herunter...
Lade archlinux-keyring-20160402-1-any.pkg.tar.xz herunter...
Lade manjaro-keyring-20160527-1-any.pkg.tar.xz herunter...
Lade pacman-5.0.1-4-x86_64.pkg.tar.xz herunter...
Lade linux-firmware-20160429.5e6165a-0.1-any.pkg.tar.xz herunter...
Lade kmod-23-1-x86_64.pkg.tar.xz herunter...
Lade mpfr-3.1.4.p1-1-x86_64.pkg.tar.xz herunter...
Lade gawk-4.1.3-1-x86_64.pkg.tar.xz herunter...
Lade mkinitcpio-busybox-1.24.2-1-x86_64.pkg.tar.xz herunter...
Lade cracklib-2.9.6-1-x86_64.pkg.tar.xz herunter...
Lade libtirpc-1.0.1-2-x86_64.pkg.tar.xz herunter...
Lade pambase-20130928-1-any.pkg.tar.xz herunter...
Lade pam-1.3.0-1-x86_64.pkg.tar.xz herunter...
Lade shadow-4.2.1-3-x86_64.pkg.tar.xz herunter...
Lade libsystemd-231-1-x86_64.pkg.tar.xz herunter...
Lade util-linux-2.28-1-x86_64.pkg.tar.xz herunter...
Lade pcre-8.39-1-x86_64.pkg.tar.xz herunter...
Lade grep-2.25-2-x86_64.pkg.tar.xz herunter...
Lade less-481-2-x86_64.pkg.tar.xz herunter...
Lade gzip-1.8-2-x86_64.pkg.tar.xz herunter...
Lade libdbus-1.10.8-1-x86_64.pkg.tar.xz herunter...
Lade dbus-1.10.8-1-x86_64.pkg.tar.xz herunter...
Lade iptables-1.6.0-1-x86_64.pkg.tar.xz herunter...
Lade kbd-2.0.3-1-x86_64.pkg.tar.xz herunter...
Lade hwids-20160421-1-any.pkg.tar.xz herunter...
Lade libelf-0.166-1-x86_64.pkg.tar.xz herunter...
Lade libseccomp-2.3.1-1-x86_64.pkg.tar.xz herunter...
Lade systemd-231-1-x86_64.pkg.tar.xz herunter...
Lade mkinitcpio-20-1-any.pkg.tar.xz herunter...
Lade linux44-4.4.16-1-x86_64.pkg.tar.xz herunter...
Lade python-3.5.2-1-x86_64.pkg.tar.xz herunter...
Lade libmnl-1.0.4-1-x86_64.pkg.tar.xz herunter...
Lade libnftnl-1.0.6-1-x86_64.pkg.tar.xz herunter...
Prüfe Schlüsselring...
Prüfe Paketintegrität...
Lade Paket-Dateien...
Prüfe auf Dateikonflikte...
Überprüfe verfügbaren Festplattenspeicher...
:: Verarbeite Paketänderungen...
Installiere linux-api-headers...
Installiere tzdata...
Installiere iana-etc...
Installiere filesystem...
Installiere glibc...
Installiere gcc-libs...
Installiere ncurses...
Installiere readline...
Installiere bash...
Optionale Abhängigkeiten für bash
    bash-completion: for tab completion
Installiere attr...
Installiere acl...
Installiere bzip2...
Installiere expat...
Installiere lz4...
Installiere lzo...
Installiere gdbm...
Installiere db...
Installiere perl...
Installiere openssl...
Optionale Abhängigkeiten für openssl
    ca-certificates [ausstehend]
Installiere xz...
Installiere zlib...
Installiere libarchive...
Installiere gmp...
Installiere libcap...
Installiere coreutils...
Installiere findutils...
Installiere libtasn1...
Installiere libffi...
Installiere p11-kit...
Installiere ca-certificates-utils...
Installiere ca-certificates-mozilla...
Installiere ca-certificates-cacert...
Installiere ca-certificates...
Installiere libutil-linux...
Installiere e2fsprogs...
Installiere libsasl...
Installiere libldap...
Installiere keyutils...
Installiere krb5...
Installiere libidn...
Installiere libssh2...
Installiere curl...
Installiere libgpg-error...
Installiere npth...
Installiere libgcrypt...
Installiere libksba...
Installiere libassuan...
Installiere pinentry...
Optionale Abhängigkeiten für pinentry
    gtk2: gtk2 backend
    qt5-base: qt backend
    gcr: gnome3 backend
Installiere nettle...
Installiere gnutls...
Optionale Abhängigkeiten für gnutls
    guile: for use with Guile bindings
Installiere sqlite...
Installiere gnupg...
Optionale Abhängigkeiten für gnupg
    libldap: gpg2keys_ldap [Installiert]
    libusb-compat: scdaemon
Installiere gpgme...
Installiere python...
Optionale Abhängigkeiten für python
    python-setuptools
    python-pip
    sqlite [Installiert]
    mpdecimal: for decimal
    xz: for lzma [Installiert]
    tk: for tkinter
Installiere pacman-mirrorlist...
:: Querying servers, this may take some time...
Africa
-> ..... http://mirror.is.co.za/mirrors/manjaro.org/unstable/$repo/$arch
-> 0.500
Australia
-> ..... http://mirror.ventraip.net.au/Manjaro/unstable/$repo/$arch
-> 0.672
-> ..... http://manjaro.uberglobalmirror.com/unstable/$repo/$arch
-> 1.018
-> ..... http://manjaro.mirror.serversaustralia.com.au/unstable/$repo/$arch
-> 1.013
Belarus
-> ..... http://mirror.datacenter.by/pub/mirrors/manjaro/unstable/$repo/$arch
-> 0.177
Belgium
-> ..... http://ftp.belnet.be/manjaro/unstable/$repo/$arch
-> 0.163
-> ..... http://manjaro.cu.be/unstable/$repo/$arch
Error: Failed to reach the server: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)
Brasil
-> ..... http://linorg.usp.br/manjaro/unstable/$repo/$arch
-> 0.586
Bulgaria
-> ..... http://mirrors.netix.net/manjaro/unstable/$repo/$arch
-> 0.142
-> ..... http://manjaro.ipacct.com/manjaro/unstable/$repo/$arch
-> 0.129
-> ..... http://manjaro.telecoms.bg/unstable/$repo/$arch
-> 0.184
Chile
-> ..... http://manjaro.dcc.uchile.cl/unstable/$repo/$arch
-> 0.863
-> ..... http://doge.ing.puc.cl/Mirrors/Manjaro/unstable/$repo/$arch
Error: Failed to reach the server: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)
China
-> ..... http://mirrors.ustc.edu.cn/manjaro/unstable/$repo/$arch
-> 1.768
-> ..... http://mirror.bjtu.edu.cn/manjaro/unstable/$repo/$arch
-> 0.981
-> ..... http://ftp.cuhk.edu.hk/pub/Linux/manjaro/unstable/$repo/$arch
-> 0.526
-> ..... http://mirrors.tuna.tsinghua.edu.cn/manjaro/unstable/$repo/$arch
-> 1.017
Colombia
-> ..... http://mirror.edatel.net.co/manjaro/unstable/$repo/$arch
-> 0.652
Costa_Rica
-> ..... http://mirrors.ucr.ac.cr/manjaro/unstable/$repo/$arch
-> 0.635
Czech
-> ..... http://mirror.dkm.cz/manjaro/unstable/$repo/$arch
-> 0.159
Ecuador
-> ..... http://mirror.cedia.org.ec/manjaro/unstable/$repo/$arch
-> 0.489
-> ..... http://mirror.uta.edu.ec/manjaro/unstable/$repo/$arch
-> 0.697
-> ..... http://mirror.espoch.edu.ec/manjaro/unstable/$repo/$arch
-> 0.452
France
-> ..... http://manjarolinux.polymorf.fr/unstable/$repo/$arch
-> 0.099
-> ..... http://mirror.lignux.com/manjaro/unstable/$repo/$arch
-> 0.136
Germany
-> ..... http://mirror.ragenetwork.de/manjaro/unstable/$repo/$arch
-> 0.263
-> ..... http://ftp.halifax.rwth-aachen.de/manjaro/unstable/$repo/$arch
-> 0.194
-> ..... http://ftp.tu-chemnitz.de/pub/linux/manjaro/unstable/$repo/$arch
-> 0.123
-> ..... http://mirror.netzspielplatz.de/manjaro/packages/unstable/$repo/$arch
-> 0.122
-> ..... http://mirror.netcologne.de/manjaro/unstable/$repo/$arch
-> 0.109
-> ..... http://h1860261.stratoserver.net/manjaro/unstable/$repo/$arch
Error: Failed to reach the server: timed out
-> ..... http://repo.rhindon.net/manjaro/unstable/$repo/$arch
Error: Failed to reach the server: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)
Greece
-> ..... http://ftp.cc.uoc.gr/mirrors/linux/manjaro/unstable/$repo/$arch
-> 0.243
Indonesia
-> ..... http://kambing.ui.ac.id/manjaro/unstable/$repo/$arch
-> 0.931
-> ..... http://kartolo.sby.datautama.net.id/manjaro/unstable/$repo/$arch
-> 0.666
-> ..... http://jaran.undip.ac.id/manjaro/unstable/$repo/$arch
-> 1.222
Ireland
-> ..... http://ftp.heanet.ie/mirrors/manjaro/unstable/$repo/$arch
-> 0.167
Italy
-> ..... http://manjaro.mirror.garr.it/mirrors/manjaro/unstable/$repo/$arch
-> 0.261
-> ..... http://ba.mirror.garr.it/mirrors/manjaro/unstable/$repo/$arch
-> 0.171
-> ..... http://ct.mirror.garr.it/mirrors/manjaro/unstable/$repo/$arch
-> 0.219
Japan
-> ..... http://ftp.tsukuba.wide.ad.jp/Linux/manjaro/unstable/$repo/$arch
-> 1.935
-> ..... http://ftp.riken.jp/Linux/manjaro/unstable/$repo/$arch
-> 0.905
Netherlands
-> ..... http://ftp.nluug.nl/pub/os/Linux/distr/manjaro/unstable/$repo/$arch
-> 0.091
-> ..... http://ftp.snt.utwente.nl/pub/linux/manjaro/unstable/$repo/$arch
-> 0.099
Philippines
-> ..... http://mirror.rise.ph/manjaro/unstable/$repo/$arch
-> 0.670
Portugal
-> ..... http://ftp.dei.uc.pt/pub/linux/manjaro/unstable/$repo/$arch
-> 0.427
Romania
-> ..... http://mirrors.xservers.ro/manjaro/unstable/$repo/$arch
-> 0.215
-> ..... http://mirrors.serverhost.ro/manjaro/packages/unstable/$repo/$arch
-> 0.249
-> ..... http://ftp.lug.ro/manjaro/unstable/$repo/$arch
-> 0.292
Russia
-> ..... http://mirror.yandex.ru/mirrors/manjaro/unstable/$repo/$arch
-> 0.169
Singapore
-> ..... http://download.nus.edu.sg/mirror/manjaro/unstable/$repo/$arch
-> 0.809
Sweden
-> ..... http://ftp.lysator.liu.se/pub/manjaro/unstable/$repo/$arch
-> 0.201
-> ..... http://mirror.zetup.net/manjaro/unstable/$repo/$arch
-> 0.206
Taiwan
-> ..... http://free.nchc.org.tw/manjaro/unstable/$repo/$arch
-> 1.043
Turkey
-> ..... http://ftp.linux.org.tr/manjaro/unstable/$repo/$arch
-> 0.316
United_Kingdom
-> ..... http://repo.manjaro.org.uk/unstable/$repo/$arch
-> 0.170
-> ..... http://www.mirrorservice.org/sites/repo.manjaro.org/repos/unstable/$repo/$arch
-> 0.142
-> ..... http://mirror.catn.com/pub/manjaro/unstable/$repo/$arch
-> 0.178
-> ..... http://manjaro.mirrors.uk2.net/unstable/$repo/$arch
-> 0.160
United_States
-> ..... http://mirror.dacentec.com/manjaro/unstable/$repo/$arch
-> 0.361
-> ..... http://lug.mtu.edu/manjaro/unstable/$repo/$arch
-> 0.328
-> ..... http://www.gtlib.gatech.edu/pub/manjaro/unstable/$repo/$arch
-> 0.442
-> ..... http://mirror.jmu.edu/manjaro/unstable/$repo/$arch
-> 0.403
-> ..... http://mirror.solarvps.com/manjaro/unstable/$repo/$arch
-> 0.422
-> ..... http://mirror.nexcess.net/manjaro/unstable/$repo/$arch
-> 0.452
-> ..... http://distro.ibiblio.org/manjaro/unstable/$repo/$arch
-> 0.427
-> ..... http://mirror.clarkson.edu/manjaro/unstable/$repo/$arch
Error: Failed to reach the server: Timeout.
Vietnam
-> ..... http://mirror.freedif.org/Manjaro/unstable/$repo/$arch
-> 0.818
:: Generated and saved '/etc/pacman.d/mirrorlist' mirrorlist.

hint: use `pacman-mirrors` to generate and update your pacman mirrorlist.
Optionale Abhängigkeiten für pacman-mirrorlist
    gtk3: for interactive mode (GUI)
    python-gobject: for interactive mode (GUI)
Installiere archlinux-keyring...
Installiere manjaro-keyring...
Installiere pacman...
[1;1m[1;32m==>[1;0m[1;1m To import the data required by pacman for package verification run:[1;0m
[1;1m[1;32m==>[1;0m[1;1m `pacman-key --init; pacman-key --populate archlinux manjaro`[1;0m
[1;1m[1;32m==>[1;0m[1;1m See: https://www.archlinux.org/news/having-pacman-verify-packages[1;0m
Optionale Abhängigkeiten für pacman
    haveged: for pacman-init.service
Installiere linux-firmware...
Installiere kmod...
Installiere mpfr...
Installiere gawk...
Installiere mkinitcpio-busybox...
Installiere cracklib...
Installiere libtirpc...
Installiere pambase...
Installiere pam...
Installiere shadow...
Installiere libsystemd...
Installiere util-linux...
Optionale Abhängigkeiten für util-linux
    python: python bindings to libmount [Installiert]
Installiere pcre...
Installiere grep...
Installiere less...
Installiere gzip...
Installiere libdbus...
Installiere dbus...
Optionale Abhängigkeiten für dbus
    libx11: dbus-launch support
Installiere libmnl...
Installiere libnftnl...
Installiere iptables...
Installiere kbd...
Installiere hwids...
Installiere libelf...
Installiere libseccomp...
Installiere systemd...
Initializing machine ID from random generator.
Created symlink /etc/systemd/system/getty.target.wants/getty@tty1.service → /usr/lib/systemd/system/getty@.service.
Created symlink /etc/systemd/system/multi-user.target.wants/remote-fs.target → /usr/lib/systemd/system/remote-fs.target.
:: Append 'init=/usr/lib/systemd/systemd' to your kernel command line in your
   bootloader to replace sysvinit with systemd, or install systemd-sysvcompat
Optionale Abhängigkeiten für systemd
    cryptsetup: required for encrypted block devices
    libmicrohttpd: remote journald capabilities
    quota-tools: kernel-level quota management
    systemd-sysvcompat: symlink package to provide sysvinit binaries
    polkit: allow administration as unprivileged user
Installiere mkinitcpio...
Optionale Abhängigkeiten für mkinitcpio
    xz: Use lzma or xz compression for the initramfs image [Installiert]
    bzip2: Use bzip2 compression for the initramfs image [Installiert]
    lzop: Use lzo compression for the initramfs image
    lz4: Use lz4 compression for the initramfs image [Installiert]
    mkinitcpio-nfs-utils: Support for root filesystem on NFS
Installiere linux44...
>>> Updating module dependencies. Please wait ...
>>> Generating initial ramdisk, using mkinitcpio.  Please wait...
==> Building image from preset: /etc/mkinitcpio.d/linux44.preset: 'default'
  -> -k /boot/vmlinuz-4.4-x86_64 -c /etc/mkinitcpio.conf -g /boot/initramfs-4.4-x86_64.img
==> Starting build: 4.4.16-1-MANJARO
  -> Running build hook: [base]
  -> Running build hook: [udev]
  -> Running build hook: [autodetect]
  -> Running build hook: [modconf]
  -> Running build hook: [block]
  -> Running build hook: [filesystems]
  -> Running build hook: [keyboard]
  -> Running build hook: [fsck]
==> Generating module dependencies
==> Creating gzip-compressed initcpio image: /boot/initramfs-4.4-x86_64.img
==> Image generation successful
==> Building image from preset: /etc/mkinitcpio.d/linux44.preset: 'fallback'
  -> -k /boot/vmlinuz-4.4-x86_64 -c /etc/mkinitcpio.conf -g /boot/initramfs-4.4-x86_64-fallback.img -S autodetect
==> Starting build: 4.4.16-1-MANJARO
  -> Running build hook: [base]
  -> Running build hook: [udev]
  -> Running build hook: [modconf]
  -> Running build hook: [block]
==> WARNING: Possibly missing firmware for module: wd719x
==> WARNING: Possibly missing firmware for module: aic94xx
  -> Running build hook: [filesystems]
  -> Running build hook: [keyboard]
  -> Running build hook: [fsck]
==> Generating module dependencies
==> Creating gzip-compressed initcpio image: /boot/initramfs-4.4-x86_64-fallback.img
==> Image generation successful
>>> WARNING: AT keyboard support is no longer built into the kernel.
>>>          In order to use your keyboard during early init, you MUST
>>>          include the 'keyboard' hook in your mkinitcpio.conf.
WARNING: It seems that grub is not installed - Your system might not boot.
Add followed initramfs files to your bootloader config:
>> linux    /boot/vmlinuz-4.4-x86_64
>> initrd   /boot/initramfs-4.4-x86_64.img
Optionale Abhängigkeiten für linux44
    crda: to set the correct wireless channels of your country
:: Starte post-transaction hooks...
(1/2) Updating udev Hardware Database...
(2/2) Rebuilding certificate stores...
01:48:43 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "pacman-key", "--init")
01:48:45 [0]: Finished. Exit code: 0
01:48:45 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "pacman-key", "--populate", "archlinux", "manjaro")
01:48:48 [0]: Finished. Exit code: 0
01:48:48 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "pacman-mirrors", "-g", "-m", "rank")
01:49:16 [0]: Finished. Exit code: 0
01:49:16 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "pacman", "-Sy", "--noconfirm", "bzip2", "coreutils", "cryptsetup", "device-mapper", "dhcpcd", "diffutils", "file", "gawk", "gcc-libs", "gettext", "glibc", "grep", "gzip", "inetutils", "iproute2", "iputils", "jfsutils", "less", "licenses", "logrotate", "lvm2", "man-db", "man-pages", "manjaro-system", "mdadm", "mhwd", "mhwd-db", "nano", "netctl", "pciutils", "pcmciautils", "procps-ng", "psmisc", "reiserfsprogs", "s-nail", "sed", "shadow", "sysfsutils", "systemd-sysvcompat", "tar", "texinfo", "usbutils", "util-linux", "vi", "which", "xfsprogs", "tcp_wrappers", "linux44", "grub", "linux-firmware", "lsb-release", "memtest86+", "os-prober", "intel-ucode", "sudo")
01:51:54 [0]: Finished. Exit code: 0
01:51:54 [0]: Starting job "machineid"
01:51:54 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemd-machine-id-setup")
01:51:54 [0]: Finished. Exit code: 0
01:51:54 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "ln", "-s", "/etc/machine-id", "/var/lib/dbus/machine-id")
01:51:54 [0]: Finished. Exit code: 0
01:51:54 [0]: Starting job "fstab"
01:51:54 [0]: Starting job "Setze Zeitzone auf Europe/Berlin"
01:51:54 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "rm", "-f", "/etc/localtime")
01:51:54 [0]: Finished. Exit code: 0
01:51:54 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "ln", "-s", "/usr/share/zoneinfo/Europe/Berlin", "/etc/localtime")
01:51:54 [0]: Finished. Exit code: 0
01:51:54 [0]: Starting job "Definiere Tastaturmodel zu pc105, Layout zu de-nodeadkeys"
01:51:54 [1]: Executing SetKeyboardLayoutJob
01:51:54 [1]: Found legacy keymap "de" with score 11
01:51:54 [1]: Found legacy keymap "de-latin1" with score 11
01:51:54 [1]: Found legacy keymap "de-latin1-nodeadkeys" with score 12
01:51:54 [1]: Written KEYMAP= "de-latin1-nodeadkeys" to vconsole.conf
01:51:54 [1]: Written XkbLayout "de" ; XkbModel "pc105" ; XkbVariant "nodeadkeys" to X.org file "/tmp/calamares-root-0pba3ams/etc/X11/xorg.conf.d/00-keyboard.conf"
01:51:54 [0]: Starting job "localegen"
01:51:54 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "locale-gen")
01:51:57 [0]: Finished. Exit code: 0
01:51:57 [0]: Starting job "luksopenswaphookcfg"
01:51:57 [0]: Starting job "luksbootkeyfile"
01:51:57 [0]: Starting job "initcpiocfg"
01:51:57 [0]: Starting job "initcpio"
01:51:57 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "mkinitcpio", "-p", "linux44")
01:52:08 [0]: Finished. Exit code: 0
01:52:08 [0]: Starting job "Erstelle Benutzer vtux"
01:52:08 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "useradd", "-m", "-s", "/bin/bash", "-U", "-G", "video,power,disk,storage,optical,network,lp,scanner,wheel", "vtux")
01:52:09 [0]: Finished. Exit code: 0
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "chfn", "-f", "vtux", "vtux")
01:52:09 [0]: Finished. Exit code: 0
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "chown", "-R", "vtux:vtux", "/home/vtux")
01:52:09 [0]: Finished. Exit code: 0
01:52:09 [0]: Starting job "Setze Passwort für Benutzer vtux"
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "usermod", "-p", "$6$vtux$9BfhMkgfxnol/OvoqpaZQySWJdOp0lZ6t.C5COESb65ApSPS1Ky6LVFV2PU1nGspJf/XYJmyhNm/fOavjREWR1", "vtux")
01:52:09 [0]: Finished. Exit code: 0
01:52:09 [0]: Starting job "Setze Passwort für Benutzer root"
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "usermod", "-p", "$6$root$kqyk6DZuXHK/TpHeiO0yLQe65.o5NNLRYERbSMpVAlQ2j8Xpth6PkkrBkJKsNj/cQu78tIzPZNg22leIar5il0", "root")
01:52:09 [0]: Finished. Exit code: 0
01:52:09 [0]: Starting job "Setze Computername auf vtux-pc"
01:52:09 [0]: Starting job "displaymanager"
01:52:09 [1]: [PYTHON JOB]:  "sddm selected but not installed"
01:52:09 [1]: [PYTHON JOB]:  "Unsetting autologin."
01:52:09 [0]: Starting job "hardwarecfg"
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Front 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Side 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Surround 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Center 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset LFE 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Headphone 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Speaker 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Line 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset External 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset FM 50% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master Mono 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master Digital 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Analog Mix 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Aux 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Aux2 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM Center 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM Front 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM LFE 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM Side 70% unmute")
01:52:09 [0]: Finished. Exit code: 127
01:52:09 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM Surround 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Playback 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset PCM,1 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset DAC 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset DAC,0 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset DAC,1 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Synth 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset CD 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Wave 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Music 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset AC97 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Analog Front 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset VIA DXS,0 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset VIA DXS,1 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset VIA DXS,2 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset VIA DXS,3 70% unmute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Mic 70% mute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset IEC958 70% mute")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master Playback Switch on")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master Surround on")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset SB Live Analog/Digital Output Jack off")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Audigy Analog/Digital Output Jack off")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master Playback Switch on")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Master Surround on")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset SB Live Analog/Digital Output Jack off")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "amixer -c 0 sset Audigy Analog/Digital Output Jack off")
01:52:10 [0]: Finished. Exit code: 127
01:52:10 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "alsactl", "-f", "/etc/asound.state", "store")
01:52:10 [0]: Finished. Exit code: 127
MHWD-Driver: no
MHWD-Video: no
[1m[31m> [mUsing config 'video-virtualbox' for device: 0000:00:02.0 (0300:80ee:beef) Display controller InnoTek Systemberatung GmbH VirtualBox Graphics Adapter
[1m[31m> [mInstalling video-virtualbox...
[0;32mUsing default
[m[0;32mHas lib32 support: true
[m[0;32mSourcing /var/lib/mhwd/db/pci/graphic_drivers/virtualbox/MHWDCONFIG
[m[0;32mProcessing classid: 0300
[m[0;32mSourcing /var/lib/mhwd/scripts/include/0300
[m[0;32m:: Synchronisiere Paketdatenbanken...
[m[0;32mLade gfx-pkgs.db herunter...
[m[0;32mLöse Abhängigkeiten auf...
[m[0;32mWarnung: Kann "libxcomposite" nicht auflösen (eine Abhängigkeit von "virtualbox-guest-utils")
[m[0;32mWarnung: Kann "libxmu" nicht auflösen (eine Abhängigkeit von "virtualbox-guest-utils")
[m[0;32mWarnung: Kann "libxt" nicht auflösen (eine Abhängigkeit von "virtualbox-guest-utils")
[m[0;32mWarnung: Kann "xorg-xrandr" nicht auflösen (eine Abhängigkeit von "virtualbox-guest-utils")
[m[0;32mWarnung: Kann "X-ABI-VIDEODRV_VERSION=19" nicht auflösen (eine Abhängigkeit von "virtualbox-guest-utils")
[m[0;32m:: Das folgende Paket kann aufgrund nicht auflösbarer Abhängigkeiten nicht aktualisiert werden:
[m[0;32m      virtualbox-guest-utils
[m[0;32m
[m[0;32m:: Möchten Sie das obengenannte Paket bei dieser Aktualisierung überspringen? [j/N] Fehler: Konnte den Vorgang nicht vorbereiten (Kann Abhängigkeiten nicht erfüllen)
[m[0;32m
[m[0;32m:: virtualbox-guest-utils: benötigt libxcomposite
[m[0;32m:: virtualbox-guest-utils: benötigt libxmu
[m[0;32m:: virtualbox-guest-utils: benötigt libxt
[m[0;32m:: virtualbox-guest-utils: benötigt xorg-xrandr
[m[0;32m:: virtualbox-guest-utils: benötigt X-ABI-VIDEODRV_VERSION=19
[m[0;32mError: pacman failed!
[m[1m[31mError: [mscript failed!
[1m[31mWarning: [mNo config found for device: 0000:00:03.0 (0200:8086:100e) Network controller Intel Corporation 82540EM Gigabit Ethernet Controller
[1m[31mWarning: [mNo device of class 0280 found!
01:52:11 [0]: Starting job "networkcfg"
01:52:11 [0]: Starting job "hwclock"
01:52:12 [0]: Starting job "services"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "bluetooth.service")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "Cannot enable systemd service bluetooth"
01:52:12 [1]: [PYTHON JOB]:  "systemctl enable call in chroot returned error code 1"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "cronie.service")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "Cannot enable systemd service cronie"
01:52:12 [1]: [PYTHON JOB]:  "systemctl enable call in chroot returned error code 1"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "ModemManager.service")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "Cannot enable systemd service ModemManager"
01:52:12 [1]: [PYTHON JOB]:  "systemctl enable call in chroot returned error code 1"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "NetworkManager.service")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "Cannot enable systemd service NetworkManager"
01:52:12 [1]: [PYTHON JOB]:  "systemctl enable call in chroot returned error code 1"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "tlp.service")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "Cannot enable systemd service tlp"
01:52:12 [1]: [PYTHON JOB]:  "systemctl enable call in chroot returned error code 1"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "tlp-sleep.service")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "Cannot enable systemd service tlp-sleep"
01:52:12 [1]: [PYTHON JOB]:  "systemctl enable call in chroot returned error code 1"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "enable", "graphical.target")
01:52:12 [0]: Finished. Exit code: 0
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "systemctl", "disable", "pacman-init.service")
01:52:12 [0]: Finished. Exit code: 0
01:52:12 [0]: Starting job "grubcfg"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "sh", "-c", "which plymouth")
01:52:12 [0]: Finished. Exit code: 1
01:52:12 [1]: [PYTHON JOB]:  "which plymouth exit code: 1"
01:52:12 [0]: Starting job "bootloader"
01:52:12 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "grub-install", "--target=i386-pc", "--recheck", "--force", "/dev/sda")
01:52:20 [0]: Finished. Exit code: 0
01:52:20 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "grub-mkconfig", "-o", "/boot/grub/grub.cfg")
01:52:26 [0]: Finished. Exit code: 0
01:52:26 [0]: Starting job "postcfg"
01:52:26 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "update-grub")
01:52:30 [0]: Finished. Exit code: 0
01:52:30 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "pacman-key", "--populate", "archlinux", "manjaro")
01:52:31 [0]: Finished. Exit code: 0
01:52:31 [0]: Running "chroot" ("/tmp/calamares-root-0pba3ams", "killall", "-9", "gpg-agent")
01:52:31 [0]: Finished. Exit code: 0
01:52:31 [0]: Starting job "umount"

```
